### PR TITLE
Removing Math.round to improve jankiness

### DIFF
--- a/src/Timer.jsx
+++ b/src/Timer.jsx
@@ -5,10 +5,10 @@ const ReactAnimationFrame = require('react-animation-frame');
 
 class Timer extends React.Component {
 	onAnimationFrame(time) {
-		const progress = Math.round(time / this.props.durationMs * 100);
+		const progress = time / this.props.durationMs * 100;
 		this.bar.style.width = `${progress}%`;
 
-		if (progress === 100) {
+		if (progress >= 100) {
 			this.props.endAnimation();
 		}
 	}


### PR DESCRIPTION
I was playing around with the demo and I saw that some frames were taking quite a long time.

Removing `Math.round` from the animation callback seems to improve the situation.

The timeline below shows a breakdown of the frame. It looks like `onAnimationFrame` is not called on certain invocations, but when I added some logging, it looked like it was being invoked every time as it should be.

![screen shot 2017-04-04 at 10 52 08](https://cloud.githubusercontent.com/assets/2573277/24651268/1e238fee-1925-11e7-8ebe-037019fb3155.png)

My guess is that Chrome dev tools is not showing an accurate representation of what's happening. `Math.round` is probably taking longer than the timeline is showing, and multiple `onAnimationFrame` invocations may be being bundled into a single `requestAnimationFrame` call.

Maybe the `react-animation-frame` project should provide some kind of API to test the performance of components passed in to it. Not sure it belongs in the project itself or if there's some other library that can be used to test these kinds of things 😕 